### PR TITLE
Set correct path to pydoctstyle settings in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -46,7 +46,7 @@ commands =
 
 [testenv:pydocstyle]
 deps = pydocstyle
-commands = pydocstyle netsgiro
+commands = pydocstyle brreg
 
 [testenv:doctest]
 changedir = docs


### PR DESCRIPTION
The settings seems to have been copied from `netsgiro`, but never updated for `brreg`.

This patch sends the correct path to pydocstyle